### PR TITLE
Add hidden OS setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # anonymos-encrypt
+
+This repository provides scripts for creating a hidden VeraCrypt volume that contains the [internetcomputer](https://github.com/Jonathan-R-Anderson/internetcomputer) operating system. The approach is similar to the [VeraCrypt Hidden Operating System](https://veracrypt.io/en/VeraCrypt%20Hidden%20Operating%20System.html), allowing the OS ISO to be stored inside a hidden volume for plausible deniability.
+
+## Requirements
+- VeraCrypt installed and accessible via the `veracrypt` command
+- `qemu` (optional, for booting the ISO)
+- Dependencies needed to build the Internet Computer OS
+
+## Usage
+1. Clone the Internet Computer repository next to this one:
+   ```bash
+   git clone https://github.com/Jonathan-R-Anderson/internetcomputer
+   ```
+2. Build the OS ISO:
+   ```bash
+   cd internetcomputer
+   make build
+   ```
+3. Run the helper script to create the hidden volume and place the ISO inside it:
+   ```bash
+   ../anonymos-encrypt/create_hidden_os.sh
+   ```
+4. Mount the resulting volume and boot the ISO if desired:
+   ```bash
+   veracrypt --text --mount anonymOS_hidden.hc /mnt
+   qemu-system-x86_64 -cdrom /mnt/anonymOS.iso
+   ```

--- a/create_hidden_os.sh
+++ b/create_hidden_os.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Create a VeraCrypt hidden volume containing the Internet Computer OS ISO.
+# The Internet Computer repository must be checked out adjacent to this one
+# and built before running this script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IC_DIR="$SCRIPT_DIR/../internetcomputer"
+ISO="$IC_DIR/build/anonymOS.iso"
+OUTER_VOL="$SCRIPT_DIR/anonymOS_outer.hc"
+HIDDEN_VOL="$SCRIPT_DIR/anonymOS_hidden.hc"
+MOUNT_DIR="$SCRIPT_DIR/hidden_mount"
+
+if [ ! -f "$ISO" ]; then
+    echo "OS ISO not found at $ISO"
+    echo "Build it first: (cd \"$IC_DIR\" && make build)"
+    exit 1
+fi
+
+read -rsp "Outer volume password: " OUTER_PASS
+echo
+read -rsp "Hidden volume password: " HIDDEN_PASS
+echo
+
+# Create outer volume
+veracrypt --text --create "$OUTER_VOL" --volume-type=normal \
+    --size=2048M --password="$OUTER_PASS" --pim=0 \
+    --hash=SHA-512 --encryption=AES --filesystem=FAT --non-interactive
+
+# Add hidden volume inside the outer one
+veracrypt --text --create "$OUTER_VOL" --volume-type=hidden \
+    --size=2048M --password="$HIDDEN_PASS" --pim=0 \
+    --hash=SHA-512 --encryption=AES --filesystem=FAT \
+    --protect-hidden=no --non-interactive
+
+mkdir -p "$MOUNT_DIR"
+veracrypt --text --password="$HIDDEN_PASS" --mount "$OUTER_VOL" "$MOUNT_DIR"
+
+cp "$ISO" "$MOUNT_DIR/"
+
+veracrypt --text --dismount "$MOUNT_DIR"
+rmdir "$MOUNT_DIR"
+
+mv "$OUTER_VOL" "$HIDDEN_VOL"
+
+echo "Hidden OS volume created at $HIDDEN_VOL"


### PR DESCRIPTION
## Summary
- document how to create a hidden volume for the `internetcomputer` OS
- provide `create_hidden_os.sh` for building a VeraCrypt hidden volume

## Testing
- `bash -n create_hidden_os.sh`


------
https://chatgpt.com/codex/tasks/task_e_6862a16b874c83278fc7f45026455706