### PR TITLE
Add D module skeletons for 10 volume classes

### DIFF
--- a/VeraCryptD/src/Volume/EncryptionMode.d
+++ b/VeraCryptD/src/Volume/EncryptionMode.d
@@ -1,0 +1,27 @@
+module Volume.EncryptionMode;
+
+import Volume.VolumePassword;
+
+class EncryptionMode
+{
+    bool keySet;
+    ulong sectorOffset;
+
+    this()
+    {
+        keySet = false;
+        sectorOffset = 0;
+    }
+
+    void decryptSectors(ubyte[] data, ulong sectorIndex, ulong sectorCount, size_t sectorSize)
+    {
+        // stub
+    }
+
+    void encryptSectors(ubyte[] data, ulong sectorIndex, ulong sectorCount, size_t sectorSize)
+    {
+        // stub
+    }
+}
+
+alias EncryptionModeList = EncryptionMode[];

--- a/VeraCryptD/src/Volume/EncryptionModeWolfCryptXTS.d
+++ b/VeraCryptD/src/Volume/EncryptionModeWolfCryptXTS.d
@@ -1,0 +1,20 @@
+module Volume.EncryptionModeWolfCryptXTS;
+
+import Volume.EncryptionMode;
+
+class EncryptionModeWolfCryptXTS : EncryptionMode
+{
+    this() {}
+
+    override void encryptSectors(ubyte[] data, ulong sectorIndex, ulong sectorCount, size_t sectorSize)
+    {
+        // stub for XTS encryption
+    }
+
+    override void decryptSectors(ubyte[] data, ulong sectorIndex, ulong sectorCount, size_t sectorSize)
+    {
+        // stub for XTS decryption
+    }
+
+    size_t getKeySize() const { return 0; }
+}

--- a/VeraCryptD/src/Volume/EncryptionThreadPool.d
+++ b/VeraCryptD/src/Volume/EncryptionThreadPool.d
@@ -1,0 +1,12 @@
+module Volume.EncryptionThreadPool;
+
+import Volume.EncryptionMode;
+
+class EncryptionThreadPool
+{
+    static void doWork(EncryptionMode mode, ubyte[] data, ulong startUnitNo, ulong unitCount, size_t sectorSize)
+    {
+        // simplified single-threaded work
+        mode.encryptSectors(data, startUnitNo, unitCount, sectorSize);
+    }
+}

--- a/VeraCryptD/src/Volume/Hash.d
+++ b/VeraCryptD/src/Volume/Hash.d
@@ -1,0 +1,12 @@
+module Volume.Hash;
+
+class Hash
+{
+    this() {}
+
+    void update(const(ubyte)[] data) {}
+    void getDigest(ubyte[] out) {}
+    string getName() const { return "HASH"; }
+}
+
+alias HashList = Hash[];

--- a/VeraCryptD/src/Volume/Keyfile.d
+++ b/VeraCryptD/src/Volume/Keyfile.d
@@ -1,0 +1,16 @@
+module Volume.Keyfile;
+
+import Volume.VolumePassword;
+
+class Keyfile
+{
+    string path;
+    this(string p) { path = p; }
+
+    static VolumePassword applyListToPassword(Keyfile[] keyfiles, VolumePassword password)
+    {
+        return password;
+    }
+}
+
+alias KeyfileList = Keyfile[];

--- a/VeraCryptD/src/Volume/Pkcs5Kdf.d
+++ b/VeraCryptD/src/Volume/Pkcs5Kdf.d
@@ -1,0 +1,17 @@
+module Volume.Pkcs5Kdf;
+
+import Volume.VolumePassword;
+
+class Pkcs5Kdf
+{
+    this() {}
+
+    void deriveKey(ubyte[] key, const VolumePassword password, int pim, const(ubyte)[] salt)
+    {
+        // placeholder
+    }
+
+    string getName() const { return "PKCS5"; }
+}
+
+alias Pkcs5KdfList = Pkcs5Kdf[];

--- a/VeraCryptD/src/Volume/VolumeInfo.d
+++ b/VeraCryptD/src/Volume/VolumeInfo.d
@@ -1,0 +1,20 @@
+module Volume.VolumeInfo;
+
+import Volume.VolumePassword;
+
+class VolumeInfo
+{
+    string mountPoint;
+    string path;
+
+    this() {}
+
+    void set() {}
+}
+
+alias VolumeInfoList = VolumeInfo[];
+
+bool firstVolumeMountedAfterSecond(VolumeInfo a, VolumeInfo b)
+{
+    return false;
+}

--- a/VeraCryptD/src/Volume/VolumeLayout.d
+++ b/VeraCryptD/src/Volume/VolumeLayout.d
@@ -1,0 +1,11 @@
+module Volume.VolumeLayout;
+
+import Volume.EncryptionMode;
+import Volume.EncryptionModeWolfCryptXTS;
+
+class VolumeLayout
+{
+    this() {}
+}
+
+alias VolumeLayoutList = VolumeLayout[];

--- a/VeraCryptD/src/Volume/VolumePassword.d
+++ b/VeraCryptD/src/Volume/VolumePassword.d
@@ -1,0 +1,37 @@
+module Volume.VolumePassword;
+
+class VolumePassword
+{
+    ubyte[] passwordBuffer;
+    size_t passwordSize;
+
+    static immutable size_t MaxLegacySize = 64;
+    static immutable size_t MaxSize = 128;
+    static immutable size_t WarningSizeThreshold = 12;
+
+    this()
+    {
+        passwordBuffer.length = MaxSize;
+        passwordSize = 0;
+    }
+
+    void set(const ubyte[] pwd)
+    {
+        if (pwd.length > MaxSize)
+            throw new Exception("Password too long");
+        passwordBuffer[0 .. pwd.length] = pwd;
+        passwordSize = pwd.length;
+    }
+
+    bool empty() const { return passwordSize == 0; }
+    size_t size() const { return passwordSize; }
+}
+
+class PasswordException : Exception
+{
+    this(string msg="") { super(msg); }
+}
+
+class PasswordIncorrect : PasswordException { this(string msg="") { super(msg); } }
+class PasswordEmpty : PasswordException { this(string msg="") { super(msg); } }
+class PasswordTooLong : PasswordException { this(string msg="") { super(msg); } }

--- a/VeraCryptD/src/Volume/VolumePasswordCache.d
+++ b/VeraCryptD/src/Volume/VolumePasswordCache.d
@@ -1,0 +1,41 @@
+module Volume.VolumePasswordCache;
+
+import Volume.VolumePassword;
+
+alias CachedPasswordList = VolumePassword[];
+
+class VolumePasswordCache
+{
+    static CachedPasswordList cachedPasswords;
+    static size_t Capacity = 4;
+
+    static CachedPasswordList getPasswords()
+    {
+        return cachedPasswords.dup;
+    }
+
+    static bool isEmpty()
+    {
+        return cachedPasswords.length == 0;
+    }
+
+    static void store(const VolumePassword pwd)
+    {
+        foreach(i, ref p; cachedPasswords)
+        {
+            if (p.size == pwd.size && p.passwordBuffer[0 .. p.size] == pwd.passwordBuffer[0 .. pwd.size])
+            {
+                cachedPasswords = cachedPasswords[0 .. i] ~ cachedPasswords[i+1 .. $];
+                break;
+            }
+        }
+        cachedPasswords = [pwd] ~ cachedPasswords;
+        if (cachedPasswords.length > Capacity)
+            cachedPasswords.length = Capacity;
+    }
+
+    static void clear()
+    {
+        cachedPasswords.length = 0;
+    }
+}


### PR DESCRIPTION
## Summary
- port several Volume-related headers from C++ to D
- implement basic stubs for passwords, keyfiles, hashing, layouts, etc.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b6d3e3b883279ee05bcac328e93b