### PR TITLE
Add D translations for main modules

### DIFF
--- a/VeraCryptD/src/Main/FavoriteVolume.d
+++ b/VeraCryptD/src/Main/FavoriteVolume.d
@@ -1,0 +1,83 @@
+module Main.FavoriteVolume;
+
+import std.file : readText, exists, remove, write;
+import std.regex : regex, matchAll;
+import std.path : buildPath, dirName;
+import std.string : replace;
+import std.conv : to;
+import Platform.Directory; // for DirectoryPath alias
+import Volume.VolumeSlot; // for VolumeSlotNumber
+
+enum VolumeProtection { None, ReadOnly, HiddenVolumeReadOnly }
+
+struct MountOptions
+{
+    string mountPoint;
+    string path;
+    VolumeProtection protection = VolumeProtection.None;
+    VolumeSlotNumber slotNumber;
+    bool partitionInSystemEncryptionScope = false;
+    bool noFilesystem = false;
+}
+
+struct FavoriteVolume
+{
+    string mountPoint;
+    string path;
+    bool readOnly = false;
+    VolumeSlotNumber slotNumber = 0;
+    bool system = false;
+
+    static FavoriteVolume[] loadList()
+    {
+        string file = buildPath(dirName(__FILE__), getFileName());
+        if (!exists(file)) return null;
+        string xml = readText(file);
+        FavoriteVolume[] list;
+        auto re = regex(`<volume[^>]*mountpoint="([^"]*)"[^>]*slotnumber="([^"]*)"[^>]*readonly="([^"]*)"[^>]*system="([^"]*)">([^<]*)</volume>`, "g");
+        foreach(m; matchAll(xml, re))
+        {
+            FavoriteVolume v;
+            v.mountPoint = m.captures[1];
+            v.slotNumber = to!uint(m.captures[2]);
+            v.readOnly = m.captures[3] != "0";
+            v.system = m.captures[4] != "0";
+            v.path = m.captures[5];
+            list ~= v;
+        }
+        return list;
+    }
+
+    static void saveList(const FavoriteVolume[] favs)
+    {
+        string file = buildPath(dirName(__FILE__), getFileName());
+        if (favs.length == 0)
+        {
+            if (exists(file)) remove(file);
+            return;
+        }
+        string[] lines;
+        lines ~= "<favorites>";
+        foreach(v; favs)
+        {
+            lines ~= "<volume mountpoint=\""~v.mountPoint~"\" slotnumber=\""~to!string(v.slotNumber)~"\" readonly=\""~(v.readOnly?"1":"0")~"\" system=\""~(v.system?"1":"0")~"\">"~v.path~"</volume>";
+        }
+        lines ~= "</favorites>";
+        write(file, lines.join("\n"));
+    }
+
+    void toMountOptions(ref MountOptions opt) const
+    {
+        opt.mountPoint = mountPoint;
+        opt.path = path;
+        opt.slotNumber = slotNumber;
+        opt.partitionInSystemEncryptionScope = system;
+        opt.protection = readOnly ? VolumeProtection.ReadOnly : VolumeProtection.None;
+        if (mountPoint.length == 0)
+            opt.noFilesystem = true;
+    }
+
+    static string getFileName() { return "Favorite Volumes.xml"; }
+}
+
+alias FavoriteVolumeList = FavoriteVolume[];

--- a/VeraCryptD/src/Main/LanguageStrings.d
+++ b/VeraCryptD/src/Main/LanguageStrings.d
@@ -1,0 +1,43 @@
+module Main.LanguageStrings;
+
+import std.regex : regex, matchAll;
+import std.file : readText, exists;
+import std.string : replace;
+import std.conv : to;
+import std.path : buildPath, dirName;
+
+class LanguageStrings
+{
+    private string[string] _map;
+    string preferredLang;
+
+    this() {}
+
+    string opIndex(string key) const
+    {
+        if (auto p = key in _map)
+            return *p;
+        if (key == "VeraCrypt")
+            return "VeraCrypt";
+        return "?" ~ key ~ "?";
+    }
+
+    bool exists(string key) const { return (key in _map) !is null; }
+
+    string get(string key) const { return this[key]; }
+
+    void init()
+    {
+        string xmlPath = buildPath(dirName(__FILE__), "../../../VeraCrypt/src/Common/Language.xml");
+        string xmlContent = exists(xmlPath) ? readText(xmlPath) : "";
+        auto re = regex(`<entry[^>]*key="([^"]+)"[^>]*>([^<]*)</entry>`, "g");
+        foreach(m; matchAll(xmlContent, re))
+        {
+            string text = replace(m.captures[2], "\\n", "\n");
+            _map[m.captures[1]] = text;
+        }
+        preferredLang = "en";
+    }
+}
+
+__gshared LanguageStrings LangString;

--- a/VeraCryptD/src/Main/StringFormatter.d
+++ b/VeraCryptD/src/Main/StringFormatter.d
@@ -1,0 +1,78 @@
+module Main.StringFormatter;
+
+import std.string : replace;
+import std.conv : to;
+import std.exception : enforce;
+
+class StringFormatterArg
+{
+    string value;
+    bool empty = true;
+    bool referenced = false;
+
+    this(){}
+    this(string v){ value = v; empty=false; }
+    this(dchar c){ value = to!string(c); empty=false; }
+    this(long n){ value = to!string(n); empty=false; }
+    this(ulong n){ value = to!string(n); empty=false; }
+
+    bool isEmpty() const { return empty; }
+    bool wasReferenced() const { return referenced; }
+
+    alias value this;
+}
+
+class StringFormatter
+{
+    wstring formatted;
+
+    this(wstring fmt, StringFormatterArg a0=StringFormatterArg(), StringFormatterArg a1=StringFormatterArg(), StringFormatterArg a2=StringFormatterArg(), StringFormatterArg a3=StringFormatterArg(), StringFormatterArg a4=StringFormatterArg(), StringFormatterArg a5=StringFormatterArg(), StringFormatterArg a6=StringFormatterArg(), StringFormatterArg a7=StringFormatterArg(), StringFormatterArg a8=StringFormatterArg(), StringFormatterArg a9=StringFormatterArg())
+    {
+        auto args = [a0,a1,a2,a3,a4,a5,a6,a7,a8,a9];
+        string text = to!string(fmt);
+        text = replace(text, "%s", "{}");
+        text = replace(text, "%d", "{}");
+        text = replace(text, "%c", "{}");
+        size_t idx=0;
+        while(true)
+        {
+            auto p = text.indexOf("{}");
+            if(p == -1) break;
+            text = text[0..p] ~ "{" ~ to!string(idx++) ~ "}" ~ text[p+2..$];
+        }
+
+        bool numberExpected=false;
+        bool endExpected=false;
+        foreach(ch; text)
+        {
+            if(numberExpected)
+            {
+                endExpected=true;
+                enforce(ch >= '0' && ch <= '9', "Format error");
+                size_t pos = ch - '0';
+                enforce(pos < args.length, "Format error");
+                formatted ~= to!wstring(args[pos].value);
+                args[pos].referenced = true;
+                numberExpected=false;
+            }
+            else if(endExpected)
+            {
+                enforce(ch == '}', "Format error");
+                endExpected=false;
+            }
+            else if(ch == '{')
+            {
+                numberExpected=true;
+            }
+            else if(ch == '}')
+            {
+                formatted ~= ch;
+                endExpected=true;
+            }
+            else
+                formatted ~= ch;
+        }
+    }
+
+    alias formatted this;
+}

--- a/VeraCryptD/src/Main/System.d
+++ b/VeraCryptD/src/Main/System.d
@@ -1,0 +1,3 @@
+module Main.System;
+
+public import Platform.System;

--- a/VeraCryptD/src/Main/VolumeHistory.d
+++ b/VeraCryptD/src/Main/VolumeHistory.d
@@ -1,0 +1,80 @@
+module Main.VolumeHistory;
+
+import std.file : readText, exists, write, remove;
+import std.path : buildPath, dirName;
+import std.regex : regex, matchAll;
+import Platform.Mutex;
+
+struct VolumeHistory
+{
+    private static string[] volumePaths;
+    private static Mutex accessMutex = new Mutex();
+
+    static void add(string path)
+    {
+        auto lock = ScopeLock(accessMutex);
+        foreach(i, p; volumePaths)
+        {
+            if (p == path)
+            {
+                volumePaths = volumePaths[0 .. i] ~ volumePaths[i+1 .. $];
+                break;
+            }
+        }
+        volumePaths = [path] ~ volumePaths;
+        if (volumePaths.length > MaxSize)
+            volumePaths.length = MaxSize;
+    }
+
+    static void clear()
+    {
+        auto lock = ScopeLock(accessMutex);
+        volumePaths.length = 0;
+        save();
+    }
+
+    static string[] get()
+    {
+        auto lock = ScopeLock(accessMutex);
+        return volumePaths.dup;
+    }
+
+    static void connectComboBox() {}
+    static void disconnectComboBox() {}
+
+    static void load()
+    {
+        auto lock = ScopeLock(accessMutex);
+        string file = historyFilePath();
+        if (!exists(file)) return;
+        string xml = readText(file);
+        auto re = regex(`<volume>([^<]+)</volume>`, "g");
+        foreach(m; matchAll(xml, re))
+            volumePaths ~= m.captures[1];
+    }
+
+    static void save()
+    {
+        auto lock = ScopeLock(accessMutex);
+        string file = historyFilePath();
+        if (volumePaths.length == 0)
+        {
+            if (exists(file)) remove(file);
+            return;
+        }
+        string[] lines;
+        lines ~= "<history>";
+        foreach(p; volumePaths)
+            lines ~= "<volume>"~p~"</volume>";
+        lines ~= "</history>";
+        write(file, lines.join("\n"));
+    }
+
+    private static string historyFilePath()
+    {
+        return buildPath(dirName(__FILE__), getFileName());
+    }
+
+    enum uint MaxSize = 10;
+    static string getFileName() { return "History.xml"; }
+}


### PR DESCRIPTION
## Summary
- port several Main components from C++ to D
- implement language string loader
- add favorite volume utilities
- implement string formatting helper
- manage volume history in D

## Testing
- `dmd --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb8f271083279416449ebd60c9e6