### PR TITLE
Add D wrappers for Unix platform

### DIFF
--- a/VeraCryptD/src/Platform/Unix/Directory.d
+++ b/VeraCryptD/src/Platform/Unix/Directory.d
@@ -1,0 +1,2 @@
+module Platform.Unix.Directory;
+public import Platform.Directory;

--- a/VeraCryptD/src/Platform/Unix/FilesystemPath.d
+++ b/VeraCryptD/src/Platform/Unix/FilesystemPath.d
@@ -1,0 +1,2 @@
+module Platform.Unix.FilesystemPath;
+public import Platform.FilesystemPath;

--- a/VeraCryptD/src/Platform/Unix/Mutex.d
+++ b/VeraCryptD/src/Platform/Unix/Mutex.d
@@ -1,0 +1,2 @@
+module Platform.Unix.Mutex;
+public import Platform.Mutex;

--- a/VeraCryptD/src/Platform/Unix/Pipe.d
+++ b/VeraCryptD/src/Platform/Unix/Pipe.d
@@ -1,0 +1,2 @@
+module Platform.Unix.Pipe;
+public import Platform.Pipe;

--- a/VeraCryptD/src/Platform/Unix/Poller.d
+++ b/VeraCryptD/src/Platform/Unix/Poller.d
@@ -1,0 +1,2 @@
+module Platform.Unix.Poller;
+public import Platform.Poller;

--- a/VeraCryptD/src/Platform/Unix/SyncEvent.d
+++ b/VeraCryptD/src/Platform/Unix/SyncEvent.d
@@ -1,0 +1,2 @@
+module Platform.Unix.SyncEvent;
+public import Platform.SyncEvent;

--- a/VeraCryptD/src/Platform/Unix/SystemException.d
+++ b/VeraCryptD/src/Platform/Unix/SystemException.d
@@ -1,0 +1,2 @@
+module Platform.Unix.SystemException;
+public import Platform.SystemException;

--- a/VeraCryptD/src/Platform/Unix/SystemInfo.d
+++ b/VeraCryptD/src/Platform/Unix/SystemInfo.d
@@ -1,0 +1,2 @@
+module Platform.Unix.SystemInfo;
+public import Platform.SystemInfo;

--- a/VeraCryptD/src/Platform/Unix/SystemLog.d
+++ b/VeraCryptD/src/Platform/Unix/SystemLog.d
@@ -1,0 +1,2 @@
+module Platform.Unix.SystemLog;
+public import Platform.SystemLog;

--- a/VeraCryptD/src/Platform/Unix/Time.d
+++ b/VeraCryptD/src/Platform/Unix/Time.d
@@ -1,0 +1,2 @@
+module Platform.Unix.Time;
+public import Platform.Time;


### PR DESCRIPTION
## Summary
- provide D wrappers for several Unix platform classes
- expose implementations for Directory, FilesystemPath, Mutex, Pipe and more under `Platform.Unix`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6862ce249d4083278e7d1ad0f6c8df7e