### PR TITLE
Add D versions of token-related headers

### DIFF
--- a/VeraCryptD/src/Common/EMVCard.d
+++ b/VeraCryptD/src/Common/EMVCard.d
@@ -1,0 +1,11 @@
+module Common.EMVCard;
+
+import Common.Token;
+
+enum EMVCardType { NONE, AMEX, MASTERCARD, VISA }
+
+class EMVCard
+{
+    this(){}
+    this(size_t slotId){}
+}

--- a/VeraCryptD/src/Common/EMVToken.d
+++ b/VeraCryptD/src/Common/EMVToken.d
@@ -1,0 +1,22 @@
+module Common.EMVToken;
+
+import Common.Token;
+import Common.EMVCard;
+
+class EMVTokenInfo : TokenInfo
+{
+    override bool isEditable() const { return false; }
+}
+
+class EMVTokenKeyfile : TokenKeyfile
+{
+    this(){ super(new TokenInfo()); }
+    this(TokenKeyfilePath path){ super(new TokenInfo()); }
+}
+
+class EMVToken
+{
+    static EMVCard[ulong] emvCards;
+    static bool isKeyfilePathValid(string path){ return path.startsWith("emv://"); }
+    static EMVTokenKeyfile[] getAvailableKeyfiles(){ EMVTokenKeyfile[] r; return r; }
+}

--- a/VeraCryptD/src/Common/IccDataExtractor.d
+++ b/VeraCryptD/src/Common/IccDataExtractor.d
@@ -1,1 +1,12 @@
 module Common.IccDataExtractor;
+
+/// Simple utility to extract raw certificate data from EMV card buffers.
+ubyte[] extractCertificate(const(ubyte)[] data)
+{
+    if (data.length <= 4)
+        return null;
+    auto len = data[1];
+    if (len + 2 <= data.length)
+        return data[2 .. 2 + len].idup;
+    return null;
+}

--- a/VeraCryptD/src/Common/PCSCException.d
+++ b/VeraCryptD/src/Common/PCSCException.d
@@ -1,0 +1,31 @@
+module Common.PCSCException;
+
+class PCSCException : Exception
+{
+    private int errorCode;
+    this(int code= -1, string msg="PCSC error")
+    {
+        super(msg);
+        errorCode = code;
+    }
+    int getErrorCode() const { return errorCode; }
+}
+
+class CommandAPDUNotValid : Exception
+{
+    this(string srcPos = "", string err="")
+    {
+        super(srcPos ~ ":" ~ err);
+    }
+}
+
+class ExtendedAPDUNotSupported : Exception { this(){super("EXTENDED_APDU_UNSUPPORTED");} }
+class ScardLibraryInitializationFailed : Exception { this(){super("SCARD_MODULE_INIT_FAILED");} }
+class EMVUnknownCardType : Exception { this(){super("EMV_UNKNOWN_CARD_TYPE");} }
+class EMVSelectAIDFailed : Exception { this(){super("EMV_SELECT_AID_FAILED");} }
+class EMVIccCertNotFound : Exception { this(){super("EMV_ICC_CERT_NOTFOUND");} }
+class EMVIssuerCertNotFound : Exception { this(){super("EMV_ISSUER_CERT_NOTFOUND");} }
+class EMVCPLCNotFound : Exception { this(){super("EMV_CPLC_NOTFOUND");} }
+class EMVKeyfileDataNotFound : Exception { this(){super("EMV_KEYFILE_DATA_NOTFOUND");} }
+class EMVPANNotFound : Exception { this(){super("EMV_PAN_NOTFOUND");} }
+class InvalidEMVPath : Exception { this(){super("INVALID_EMV_PATH");} }

--- a/VeraCryptD/src/Common/SCard.d
+++ b/VeraCryptD/src/Common/SCard.d
@@ -1,0 +1,12 @@
+module Common.SCard;
+
+import Common.SCardManager;
+
+class SCard
+{
+    static SCardManager manager = new SCardManager();
+    this(){}
+    this(size_t slotId){ }
+    ~this(){}
+    bool isCardHandleValid() const { return false; }
+}

--- a/VeraCryptD/src/Common/SCardLoader.d
+++ b/VeraCryptD/src/Common/SCardLoader.d
@@ -1,0 +1,7 @@
+module Common.SCardLoader;
+
+class SCardLoader
+{
+    static void initialize(){}
+    static void finalize(){}
+}

--- a/VeraCryptD/src/Common/SCardManager.d
+++ b/VeraCryptD/src/Common/SCardManager.d
@@ -1,0 +1,12 @@
+module Common.SCardManager;
+
+import std.stdio;
+import std.array;
+
+class SCardManager
+{
+    this(){}
+    ~this(){}
+    static string[] getReaders(){ return []; }
+    static Object getReader(size_t idx){ return null; }
+}

--- a/VeraCryptD/src/Common/SCardReader.d
+++ b/VeraCryptD/src/Common/SCardReader.d
@@ -1,0 +1,10 @@
+module Common.SCardReader;
+
+import Common.SCardLoader;
+import std.array;
+
+class SCardReader
+{
+    this(string name, SCardLoader loader){}
+    bool isCardPresent(){ return false; }
+}

--- a/VeraCryptD/src/Common/SecurityToken.d
+++ b/VeraCryptD/src/Common/SecurityToken.d
@@ -1,0 +1,22 @@
+module Common.SecurityToken;
+
+import Common.Token;
+
+class SecurityTokenInfo : TokenInfo
+{
+    uint flags = 0;
+    string labelUtf8;
+}
+
+class SecurityTokenKeyfile : TokenKeyfile
+{
+    this(){ super(new TokenInfo()); }
+    this(TokenKeyfilePath path){ super(new TokenInfo()); }
+}
+
+class SecurityToken
+{
+    static bool initialized;
+    static void initLibrary(string path){ initialized = true; }
+    static bool isInitialized(){ return initialized; }
+}

--- a/VeraCryptD/src/Common/Token.d
+++ b/VeraCryptD/src/Common/Token.d
@@ -1,0 +1,30 @@
+module Common.Token;
+
+struct TokenKeyfilePath
+{
+    string path;
+    this(string p){ path = p; }
+    override string toString() const { return path; }
+}
+
+class TokenInfo
+{
+    ulong slotId = 0;
+    string label;
+    bool isEditable() const { return true; }
+}
+
+class TokenKeyfile
+{
+    TokenInfo token;
+    string id;
+    this(TokenInfo t){ token = t; }
+    TokenKeyfilePath toPath() const { return TokenKeyfilePath(id); }
+    void getKeyfileData(ref ubyte[] out){ }
+}
+
+class Token
+{
+    static TokenKeyfile[] getAvailableKeyfiles(bool emv=false){ TokenKeyfile[] t; return t; }
+    static bool isKeyfilePathValid(string path, bool emv=false){ return path.length>0; }
+}

--- a/VeraCryptD/src/Main/UserInterfaceException.d
+++ b/VeraCryptD/src/Main/UserInterfaceException.d
@@ -1,0 +1,11 @@
+module Main.UserInterfaceException;
+
+class MissingArgumentException : Exception
+{
+    this(string msg="Missing argument"){ super(msg); }
+}
+
+class UnrecognizedCommandException : Exception
+{
+    this(string msg="Unrecognized command"){ super(msg); }
+}

--- a/VeraCryptD/src/Main/UserInterfaceType.d
+++ b/VeraCryptD/src/Main/UserInterfaceType.d
@@ -1,0 +1,8 @@
+module Main.UserInterfaceType;
+
+enum UserInterfaceType
+{
+    Unknown,
+    Graphic,
+    Text
+}

--- a/VeraCryptD/src/Platform/System.d
+++ b/VeraCryptD/src/Platform/System.d
@@ -1,2 +1,17 @@
 module Platform.System;
-// Placeholder for system-specific utilities
+
+import core.stdc.stdlib : getenv;
+import core.thread : Thread;
+import std.string : toStringz, fromStringz;
+import std.datetime : msecs, dur;
+
+string getEnv(string name)
+{
+    auto p = getenv(name.toStringz);
+    return p ? cast(string) p.fromStringz : "";
+}
+
+void sleepMs(int ms)
+{
+    Thread.sleep(dur!msecs(ms));
+}


### PR DESCRIPTION
## Summary
- create D implementations for system helpers
- convert token and smartcard-related headers to D modules
- add simple user interface exception and type modules
- implement a minimal ICC certificate extractor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68630c0ffbc083278a6ea71e9d7e2fa0