### PR TITLE
Add D translations for boot code

### DIFF
--- a/VeraCryptD/src/Boot/Windows/BootConfig.d
+++ b/VeraCryptD/src/Boot/Windows/BootConfig.d
@@ -1,0 +1,95 @@
+module Boot.Windows.BootConfig;
+
+import Boot.Windows.BootDiskIo;
+import Boot.Windows.BootDefs;
+import Boot.Windows.BootConsoleIo;
+import Boot.Windows.BootStrings;
+import Boot.Windows.BootDebug;
+
+__gshared ubyte BootSectorFlags;
+__gshared ubyte BootLoaderDrive;
+__gshared ubyte BootDrive;
+__gshared bool BootDriveGeometryValid = false;
+__gshared bool PreventNormalSystemBoot = false;
+__gshared bool PreventBootMenu = false;
+__gshared char[TC_BOOT_SECTOR_USER_MESSAGE_MAX_LENGTH + 1] CustomUserMessage;
+__gshared uint OuterVolumeBackupHeaderCrc;
+
+__gshared bool BootStarted = false;
+
+__gshared DriveGeometry BootDriveGeometry;
+__gshared CRYPTO_INFO* BootCryptoInfo;
+__gshared Partition EncryptedVirtualPartition;
+
+__gshared Partition ActivePartition;
+__gshared Partition PartitionFollowingActive;
+__gshared bool ExtraBootPartitionPresent = false;
+__gshared ulong PimValueOrHiddenVolumeStartUnitNo;
+__gshared ulong HiddenVolumeStartSector;
+
+version(TC_WINDOWS_BOOT_RESCUE_DISK_MODE) {}
+else
+{
+    void ReadBootSectorUserConfiguration()
+    {
+        ubyte userConfig;
+
+        AcquireSectorBuffer();
+
+        if (ReadWriteMBR(false, BootLoaderDrive, true) != BiosResult.Success)
+            goto ret;
+
+        userConfig = SectorBuffer[TC_BOOT_SECTOR_USER_CONFIG_OFFSET];
+
+        PreventBootMenu = (userConfig & TC_BOOT_USER_CFG_FLAG_DISABLE_ESC) != 0;
+
+        memcpy(CustomUserMessage.ptr, SectorBuffer.ptr + TC_BOOT_SECTOR_USER_MESSAGE_OFFSET,
+               TC_BOOT_SECTOR_USER_MESSAGE_MAX_LENGTH);
+        CustomUserMessage[TC_BOOT_SECTOR_USER_MESSAGE_MAX_LENGTH] = 0;
+
+        if ((userConfig & TC_BOOT_USER_CFG_FLAG_SILENT_MODE) != 0)
+        {
+            if (CustomUserMessage[0])
+            {
+                InitVideoMode();
+                Print(CustomUserMessage.ptr);
+            }
+
+            DisableScreenOutput();
+        }
+
+        if ((userConfig & TC_BOOT_USER_CFG_FLAG_DISABLE_PIM) != 0)
+        {
+            PimValueOrHiddenVolumeStartUnitNo = 0;
+            memcpy(&PimValueOrHiddenVolumeStartUnitNo, SectorBuffer.ptr + TC_BOOT_SECTOR_PIM_VALUE_OFFSET,
+                   TC_BOOT_SECTOR_PIM_VALUE_SIZE);
+        }
+        else
+            PimValueOrHiddenVolumeStartUnitNo = cast(ulong)-1;
+
+        OuterVolumeBackupHeaderCrc = *cast(uint*)(SectorBuffer.ptr + TC_BOOT_SECTOR_OUTER_VOLUME_BAK_HEADER_CRC_OFFSET);
+
+    ret:
+        ReleaseSectorBuffer();
+    }
+
+    BiosResult UpdateBootSectorConfiguration(ubyte drive)
+    {
+        ulong mbrSector = 0;
+
+        AcquireSectorBuffer();
+        BiosResult result = ReadWriteSectors(false, TC_BOOT_LOADER_BUFFER_SEGMENT, 0, drive, mbrSector, 8, false);
+        if (result != BiosResult.Success)
+            goto ret;
+
+        CopyMemory(TC_BOOT_LOADER_BUFFER_SEGMENT, 0, SectorBuffer.ptr, TC_LB_SIZE);
+        SectorBuffer[TC_BOOT_SECTOR_CONFIG_OFFSET] = BootSectorFlags;
+        CopyMemory(SectorBuffer.ptr, TC_BOOT_LOADER_BUFFER_SEGMENT,0, TC_LB_SIZE);
+
+        result = ReadWriteSectors(true, TC_BOOT_LOADER_BUFFER_SEGMENT, 0, drive, mbrSector, 8, false);
+
+    ret:
+        ReleaseSectorBuffer();
+        return result;
+    }
+}

--- a/VeraCryptD/src/Boot/Windows/BootConsoleIo.d
+++ b/VeraCryptD/src/Boot/Windows/BootConsoleIo.d
@@ -1,0 +1,304 @@
+module Boot.Windows.BootConsoleIo;
+
+import Boot.Windows.BootDebug;
+import Boot.Windows.BootStrings;
+import Boot.Windows.BootDefs;
+
+enum uint TC_DEBUG_PORT = 0;
+
+enum uint TC_BIOS_KEY_ESC = 1;
+enum uint TC_BIOS_KEY_BACKSPACE = 14;
+enum uint TC_BIOS_KEY_ENTER = 28;
+enum uint TC_BIOS_KEY_F1 = 0x3b;
+enum uint TC_BIOS_KEY_F2 = 0x3c;
+enum uint TC_BIOS_KEY_F3 = 0x3d;
+enum uint TC_BIOS_KEY_F4 = 0x3e;
+enum uint TC_BIOS_KEY_F5 = 0x3f;
+enum uint TC_BIOS_KEY_F6 = 0x40;
+enum uint TC_BIOS_KEY_F7 = 0x41;
+enum uint TC_BIOS_KEY_F8 = 0x42;
+enum uint TC_BIOS_KEY_F9 = 0x43;
+enum uint TC_BIOS_KEY_F10 = 0x44;
+
+enum uint TC_BIOS_SHIFTMASK_CAPSLOCK      = (1 << 6);
+enum uint TC_BIOS_SHIFTMASK_LSHIFT        = (1 << 1);
+enum uint TC_BIOS_SHIFTMASK_RSHIFT        = (1 << 0);
+
+enum uint TC_BIOS_CHAR_BACKSPACE          = 8;
+
+enum uint TC_BIOS_MAX_CHARS_PER_LINE      = 80;
+
+void Beep()
+{
+    PrintChar(7);
+}
+
+static int ScreenOutputDisabled = 0;
+
+version(TC_TRACE_INT13) {}
+version(TC_WINDOWS_BOOT_RESCUE_DISK_MODE) {}
+
+void DisableScreenOutput()
+{
+    ++ScreenOutputDisabled;
+}
+
+void EnableScreenOutput()
+{
+    --ScreenOutputDisabled;
+}
+
+void PrintChar(char c)
+{
+    version(TC_BOOT_TRACING_ENABLED)
+        WriteDebugPort(cast(ubyte)c);
+
+    if (ScreenOutputDisabled)
+        return;
+
+    asm {
+        mov bx, 7;
+        mov al, c;
+        mov ah, 0xe;
+        int 0x10;
+    }
+}
+
+void PrintCharAtCursor(char c)
+{
+    if (ScreenOutputDisabled)
+        return;
+    asm {
+        mov bx, 7;
+        mov al, c;
+        mov cx, 1;
+        mov ah, 0xa;
+        int 0x10;
+    }
+}
+
+void Print(const(char)* str)
+{
+    char c;
+    size_t i = 0;
+    while ((c = str[i++]))
+        PrintChar(c);
+}
+
+void Print(uint number)
+{
+    char[12] str;
+    int pos = 0;
+    uint n = number;
+    while (n >= 10)
+    {
+        str[pos++] = cast(char)(n % 10) + '0';
+        n /= 10;
+    }
+    str[pos] = cast(char)(n % 10) + '0';
+    while (pos >= 0)
+        PrintChar(str[pos--]);
+}
+
+void Print(const(ulong) number)
+{
+    if (number >> 32 == 0)
+        Print(cast(uint)number);
+    else
+        PrintHex(number);
+}
+
+void PrintHex(ubyte b)
+{
+    PrintChar(((b >> 4) >= 0xA ? 'A' - 0xA : '0') + (b >> 4));
+    PrintChar(((b & 0xF) >= 0xA ? 'A' - 0xA : '0') + (b & 0xF));
+}
+
+void PrintHex(ushort data)
+{
+    PrintHex(cast(ubyte)(data >> 8));
+    PrintHex(cast(ubyte)data);
+}
+
+void PrintHex(uint data)
+{
+    PrintHex(cast(ushort)(data >> 16));
+    PrintHex(cast(ushort)data);
+}
+
+void PrintHex(const(ulong) data)
+{
+    PrintHex(cast(uint)(data >> 32));
+    PrintHex(cast(uint)data);
+}
+
+void PrintRepeatedChar(char c, int n)
+{
+    while (n-- > 0)
+        PrintChar(c);
+}
+
+void PrintEndl()
+{
+    Print("\r\n");
+}
+
+void PrintEndl(int cnt)
+{
+    while (cnt-- > 0)
+        PrintEndl();
+}
+
+void InitVideoMode()
+{
+    if (ScreenOutputDisabled)
+        return;
+    asm {
+        mov ax, 3;
+        int 0x10;
+        mov ax, 0x500;
+        int 0x10;
+    }
+}
+
+void ClearScreen()
+{
+    if (ScreenOutputDisabled)
+        return;
+    asm {
+        mov bh, 7;
+        xor cx, cx;
+        mov dx, 0x184f;
+        mov ax, 0x600;
+        int 0x10;
+        xor bh, bh;
+        xor dx, dx;
+        mov ah, 2;
+        int 0x10;
+    }
+}
+
+void PrintBackspace()
+{
+    PrintChar(TC_BIOS_CHAR_BACKSPACE);
+    PrintCharAtCursor(' ');
+}
+
+void PrintError(const(char)* message)
+{
+    Print(TC_BOOT_STR_ERROR.ptr);
+    Print(message);
+    PrintEndl();
+    Beep();
+}
+
+void PrintErrorNoEndl(const(char)* message)
+{
+    Print(TC_BOOT_STR_ERROR.ptr);
+    Print(message);
+    Beep();
+}
+
+ubyte GetShiftFlags()
+{
+    ubyte flags;
+    asm {
+        mov ah, 2;
+        int 0x16;
+        mov flags, al;
+    }
+    return flags;
+}
+
+ubyte GetKeyboardChar()
+{
+    return GetKeyboardChar(null);
+}
+
+ubyte GetKeyboardChar(ubyte* scanCode)
+{
+    while (!IsKeyboardCharAvailable())
+    {
+        asm { hlt; }
+    }
+    ubyte asciiCode;
+    ubyte scan;
+    asm {
+        mov ah, 0;
+        int 0x16;
+        mov asciiCode, al;
+        mov scan, ah;
+    }
+    if (scanCode)
+        *scanCode = scan;
+    return asciiCode;
+}
+
+bool IsKeyboardCharAvailable()
+{
+    bool available = false;
+    asm {
+        mov ah, 1;
+        int 0x16;
+        jz not_avail;
+        mov available, 1;
+    not_avail:
+    }
+    return available;
+}
+
+bool EscKeyPressed()
+{
+    if (IsKeyboardCharAvailable())
+    {
+        ubyte keyScanCode;
+        GetKeyboardChar(&keyScanCode);
+        return keyScanCode == TC_BIOS_KEY_ESC;
+    }
+    return false;
+}
+
+void ClearBiosKeystrokeBuffer()
+{
+    asm {
+        push es;
+        xor ax, ax;
+        mov es, ax;
+        mov di, 0x41e;
+        mov cx, 32;
+        cld;
+        rep stosb;
+        mov ax, 0x001e;
+        mov es:[0x41a], ax;
+        mov es:[0x41c], ax;
+        pop es;
+    }
+}
+
+bool IsPrintable(char c)
+{
+    return c >= ' ' && c <= '~';
+}
+
+bool IsDigit(char c)
+{
+    return c >= '0' && c <= '9';
+}
+
+int GetString(char* buffer, size_t bufferSize)
+{
+    ubyte c;
+    ubyte scanCode;
+    size_t pos = 0;
+    while (pos < bufferSize)
+    {
+        c = GetKeyboardChar(&scanCode);
+        if (scanCode == TC_BIOS_KEY_ENTER)
+            break;
+        if (scanCode == TC_BIOS_KEY_ESC)
+            return 0;
+        buffer[pos++] = c;
+        PrintChar(IsPrintable(c) ? c : ' ');
+    }
+    return cast(int)pos;
+}

--- a/VeraCryptD/src/Boot/Windows/BootDebug.d
+++ b/VeraCryptD/src/Boot/Windows/BootDebug.d
@@ -1,17 +1,161 @@
 module Boot.Windows.BootDebug;
 
-import std.stdio : writefln;
+import Boot.Windows.BootConsoleIo;
+import Boot.Windows.BootDefs;
 
-void initDebugPort() {}
-void initStackChecker() {}
-void writeDebugPort(ubyte dataByte) {}
-void printHexDump(const(ubyte)[] mem, size_t size, ushort* memSegment = null) {
-    foreach(i; 0 .. size) writefln("%02X", mem[i]);
+version(TC_BOOT_TRACING_ENABLED)
+{
+    void initDebugPort()
+    {
+        asm {
+            mov dx, TC_DEBUG_PORT;
+            mov ah, 1;
+            int 0x17;
+            mov dx, TC_DEBUG_PORT;
+            mov ah, 0xe2;
+            int 0x17;
+        }
+    }
+
+    void writeDebugPort(ubyte dataByte)
+    {
+        asm {
+            mov al, dataByte;
+            mov dx, TC_DEBUG_PORT;
+            mov ah, 0;
+            int 0x17;
+        }
+    }
 }
-void printHexDump(ushort memSegment, ushort memOffset, size_t size) {}
-void printVal(string message, uint value, bool newLine=true, bool hex=false) {
-    if(hex) writefln("%s %X", message, value); else writefln("%s %d", message, value);
+else
+{
+    void initDebugPort() {}
+    void writeDebugPort(ubyte dataByte) {}
 }
-void printVal(string message, ulong value, bool newLine=true, bool hex=false) {
-    if(hex) writefln("%s %X", message, value); else writefln("%s %d", message, value);
+
+version(TC_BOOT_DEBUG_ENABLED)
+{
+    extern(C) void PrintDebug(uint debugVal)
+    {
+        Print(debugVal);
+        PrintEndl();
+    }
+
+    void printVal(const(char)* message, uint value, bool newLine=true, bool hex=false)
+    {
+        Print(message);
+        Print(": ");
+        if (hex)
+            PrintHex(value);
+        else
+            Print(value);
+        if (newLine)
+            PrintEndl();
+    }
+
+    void printVal(const(char)* message, ulong value, bool newLine=true, bool hex=false)
+    {
+        Print(message);
+        Print(": ");
+        PrintHex(value);
+        if (newLine)
+            PrintEndl();
+    }
+
+    void printHexDump(ubyte* mem, size_t size, ushort* memSegment=null)
+    {
+        enum size_t width = 16;
+        for (size_t pos = 0; pos < size; )
+        {
+            foreach(pass; 1 .. 3)
+            {
+                size_t i;
+                for (i = 0; i < width && pos < size; ++i)
+                {
+                    ubyte dataByte;
+                    if (memSegment)
+                    {
+                        asm {
+                            push es;
+                            mov si, memSegment;
+                            mov es, [si];
+                            mov si, mem;
+                            add si, pos;
+                            mov al, es:[si];
+                            mov dataByte, al;
+                            pop es;
+                        }
+                        ++pos;
+                    }
+                    else
+                        dataByte = mem[pos++];
+                    if (pass == 1)
+                    {
+                        PrintHex(dataByte);
+                        PrintChar(' ');
+                    }
+                    else
+                        PrintChar(IsPrintable(cast(char)dataByte) ? cast(char)dataByte : '.');
+                }
+                if (pass == 1)
+                {
+                    pos -= i;
+                    PrintChar(' ');
+                }
+            }
+            PrintEndl();
+        }
+    }
+
+    void printHexDump(ushort memSegment, ushort memOffset, size_t size)
+    {
+        printHexDump(cast(ubyte*)memOffset, size, &memSegment);
+    }
+}
+else
+{
+    void printHexDump(const(ubyte)[] mem, size_t size, ushort* memSegment=null) {}
+    void printHexDump(ushort memSegment, ushort memOffset, size_t size) {}
+    void printVal(const(char)* m, uint v, bool nl=true, bool hex=false) {}
+    void printVal(const(char)* m, ulong v, bool nl=true, bool hex=false) {}
+}
+
+version(TC_BOOT_STACK_CHECKING_ENABLED)
+{
+    extern(C) __gshared char end[];
+
+    static void PrintStackInfo()
+    {
+        ushort spReg;
+        asm mov spReg, sp;
+        Print("Stack: ");
+        Print(TC_BOOT_LOADER_STACK_TOP - spReg);
+        Print("/");
+        Print(TC_BOOT_LOADER_STACK_TOP - cast(ushort) end);
+    }
+
+    void checkStack()
+    {
+        ushort spReg;
+        asm mov spReg, sp;
+        if (*cast(uint*)end != 0x12345678UL || spReg < cast(ushort)end)
+        {
+            asm cli;
+            asm mov sp, TC_BOOT_LOADER_STACK_TOP;
+            PrintError("Stack overflow");
+            assert(0);
+        }
+    }
+
+    void initStackChecker()
+    {
+        *cast(uint*)end = 0x12345678UL;
+        PrintStackInfo();
+        PrintEndl();
+    }
+}
+else
+{
+    void checkStack() {}
+    void initStackChecker() {}
 }

--- a/VeraCryptD/src/Boot/Windows/BootDiskIo.d
+++ b/VeraCryptD/src/Boot/Windows/BootDiskIo.d
@@ -1,0 +1,274 @@
+module Boot.Windows.BootDiskIo;
+
+import Boot.Windows.BootConsoleIo;
+import Boot.Windows.BootDefs;
+import Boot.Windows.BootDebug;
+import Boot.Windows.Bios;
+
+enum uint TC_MAX_BIOS_DISK_IO_RETRIES = 5;
+
+enum BiosResultEccCorrected = 0x11;
+
+#pragma pack(push,1)
+struct PartitionEntryMBR
+{
+    ubyte BootIndicator;
+    ubyte StartHead;
+    ubyte StartCylSector;
+    ubyte StartCylinder;
+    ubyte Type;
+    ubyte EndHead;
+    ubyte EndSector;
+    ubyte EndCylinder;
+    uint StartLBA;
+    uint SectorCountLBA;
+}
+
+struct MBR
+{
+    ubyte[446] Code;
+    PartitionEntryMBR[4] Partitions;
+    ushort Signature;
+}
+
+struct BiosLbaPacket
+{
+    ubyte Size;
+    ubyte Reserved;
+    ushort SectorCount;
+    uint Buffer;
+    ulong Sector;
+}
+#pragma pack(pop)
+
+struct ChsAddress
+{
+    ushort Cylinder;
+    ubyte Head;
+    ubyte Sector;
+}
+
+struct Partition
+{
+    ubyte Number;
+    ubyte Drive;
+    bool Active;
+    ulong EndSector;
+    bool Primary;
+    ulong SectorCount;
+    ulong StartSector;
+    ubyte Type;
+}
+
+struct DriveGeometry
+{
+    ushort Cylinders;
+    ubyte Heads;
+    ubyte Sectors;
+}
+
+__gshared ubyte[TC_LB_SIZE] SectorBuffer;
+
+version(TC_BOOT_DEBUG_ENABLED)
+{
+    static bool SectorBufferInUse = false;
+    void AcquireSectorBuffer()
+    {
+        if (SectorBufferInUse)
+            assert(0);
+        SectorBufferInUse = true;
+    }
+    void ReleaseSectorBuffer()
+    {
+        SectorBufferInUse = false;
+    }
+}
+else
+{
+    void AcquireSectorBuffer() {}
+    void ReleaseSectorBuffer() {}
+}
+
+bool IsLbaSupported(ubyte drive)
+{
+    static ubyte CachedDrive = TC_INVALID_BIOS_DRIVE;
+    static bool CachedStatus;
+    ushort result = 0;
+    if (CachedDrive == drive)
+        return CachedStatus;
+    asm {
+        mov bx, 0x55aa;
+        mov dl, drive;
+        mov ah, 0x41;
+        int 0x13;
+        jc err;
+        mov result, bx;
+    err:
+    }
+    CachedDrive = drive;
+    CachedStatus = (result == 0xaa55);
+    return CachedStatus;
+}
+
+void Print(const ChsAddress* chs)
+{
+    Print(chs.Cylinder);
+    PrintChar('/');
+    Print(chs.Head);
+    PrintChar('/');
+    Print(chs.Sector);
+}
+
+void PrintSectorCountInMB(const ulong sectorCount)
+{
+    Print(sectorCount >> (TC_LB_SIZE_BIT_SHIFT_DIVISOR + 2));
+    Print(" MiB");
+}
+
+void PrintDiskError(BiosResult error, bool write, ubyte drive, const ulong* sector, const ChsAddress* chs=null)
+{
+    PrintEndl();
+    Print(write ? "Write" : "Read");
+    Print(" error:");
+    Print(cast<uint>error);
+    Print(" Drive:");
+    Print(drive ^ 0x80);
+    if (sector)
+    {
+        Print(" Sector:");
+        Print(*sector);
+    }
+    if (chs)
+    {
+        Print(" CHS:");
+        Print(*chs);
+    }
+    PrintEndl();
+    Beep();
+}
+
+BiosResult ReadWriteSectors(bool write, BiosLbaPacket* dapPacket, ubyte drive, const ulong sector, ushort sectorCount, bool silent)
+{
+    CheckStack();
+    ubyte function = write ? 0x43 : 0x42;
+    BiosResult result;
+    ubyte tryCount = TC_MAX_BIOS_DISK_IO_RETRIES;
+    do
+    {
+        result = BiosResult.Success;
+        asm {
+            mov bx, 0x55aa;
+            mov dl, drive;
+            mov si, dapPacket;
+            mov ah, function;
+            xor al, al;
+            int 0x13;
+            jnc ok;
+            mov result, ah;
+        ok:
+        }
+        if (result == BiosResultEccCorrected)
+            result = BiosResult.Success;
+    } while (result != BiosResult.Success && --tryCount != 0);
+    if (!silent && result != BiosResult.Success)
+        PrintDiskError(result, write, drive, &sector);
+    return result;
+}
+
+BiosResult ReadWriteSectors(bool write, ushort bufferSegment, ushort bufferOffset, ubyte drive, const ulong sector, ushort sectorCount, bool silent)
+{
+    BiosLbaPacket dap;
+    dap.Buffer = (cast(uint)bufferSegment << 16) | bufferOffset;
+    dap.Sector = sector;
+    dap.SectorCount = sectorCount;
+    return ReadWriteSectors(write, &dap, drive, sector, sectorCount, silent);
+}
+
+BiosResult ReadWriteSectors(bool write, ubyte* buffer, ubyte drive, const ulong sector, ushort sectorCount, bool silent)
+{
+    BiosLbaPacket dap;
+    dap.Buffer = cast(uint)buffer;
+    dap.Sector = sector;
+    dap.SectorCount = sectorCount;
+    return ReadWriteSectors(write, &dap, drive, sector, sectorCount, silent);
+}
+
+BiosResult ReadSectors(ushort bufferSegment, ushort bufferOffset, ubyte drive, const ulong sector, ushort sectorCount, bool silent)
+{
+    return ReadWriteSectors(false, bufferSegment, bufferOffset, drive, sector, sectorCount, silent);
+}
+
+BiosResult ReadSectors(ubyte* buffer, ubyte drive, const ulong sector, ushort sectorCount, bool silent)
+{
+    BiosResult result;
+    ushort codeSeg;
+    asm mov codeSeg, cs;
+    result = ReadSectors(BootStarted ? codeSeg : TC_BOOT_LOADER_ALT_SEGMENT, cast(ushort)buffer, drive, sector, sectorCount, silent);
+    if (!BootStarted)
+        CopyMemory(TC_BOOT_LOADER_ALT_SEGMENT, cast(ushort)buffer, buffer, sectorCount * TC_LB_SIZE);
+    return result;
+}
+
+BiosResult WriteSectors(ubyte* buffer, ubyte drive, const ulong sector, ushort sectorCount, bool silent)
+{
+    return ReadWriteSectors(true, buffer, drive, sector, sectorCount, silent);
+}
+
+BiosResult GetDriveGeometry(ubyte drive, DriveGeometry* geometry, bool silent)
+{
+    CheckStack();
+    ubyte maxCylinderLow;
+    ubyte maxHead;
+    ubyte maxSector;
+    BiosResult result;
+    asm {
+        push es;
+        mov dl, drive;
+        mov ah, 0x08;
+        int 0x13;
+        mov result, ah;
+        mov maxCylinderLow, ch;
+        mov maxSector, cl;
+        mov maxHead, dh;
+        pop es;
+    }
+    if (result == BiosResult.Success)
+    {
+        geometry.Cylinders = (maxCylinderLow | (cast(ushort)(maxSector & 0xc0) << 2)) + 1;
+        geometry.Heads = maxHead + 1;
+        geometry.Sectors = maxSector & ~0xc0;
+    }
+    else if (!silent)
+    {
+        Print("Drive ");
+        Print(drive ^ 0x80);
+        Print(" not found: ");
+        PrintErrorNoEndl("");
+        Print(cast<uint>result);
+        PrintEndl();
+    }
+    return result;
+}
+
+void ChsToLba(const DriveGeometry* geometry, const ChsAddress* chs, ulong* lba)
+{
+    lba.high = 0;
+    lba.low = (cast(uint)(chs.Cylinder) * geometry.Heads + chs.Head) * geometry.Sectors + chs.Sector - 1;
+}
+
+void LbaToChs(const DriveGeometry* geometry, const ulong lba, ChsAddress* chs)
+{
+    chs.Sector = cast(ubyte)((lba.low % geometry.Sectors) + 1);
+    uint ch = lba.low / geometry.Sectors;
+    chs.Head = cast(ubyte)(ch % geometry.Heads);
+    chs.Cylinder = cast(ushort)(ch / geometry.Heads);
+}
+
+BiosResult ReadWriteMBR(bool write, ubyte drive, bool silent=false)
+{
+    ulong mbrSector = 0;
+    if (write)
+        return WriteSectors(SectorBuffer.ptr, drive, mbrSector, 1, silent);
+    return ReadSectors(SectorBuffer.ptr, drive, mbrSector, 1, silent);
+}
+

--- a/VeraCryptD/src/Boot/Windows/BootEncryptedIo.d
+++ b/VeraCryptD/src/Boot/Windows/BootEncryptedIo.d
@@ -1,0 +1,107 @@
+module Boot.Windows.BootEncryptedIo;
+
+import Boot.Windows.BootDiskIo;
+import Boot.Windows.BootConfig;
+import Boot.Windows.BootDefs;
+import Boot.Windows.BootDebug;
+
+BiosResult ReadEncryptedSectors(ushort destSegment, ushort destOffset, ubyte drive, ulong sector, ushort sectorCount)
+{
+    BiosResult result;
+    bool decrypt = true;
+
+    if (BootCryptoInfo.hiddenVolume)
+    {
+        if (ReadWritePartiallyCoversEncryptedArea(sector, sectorCount))
+            return BiosResult.InvalidFunction;
+        if (sector >= EncryptedVirtualPartition.StartSector && sector <= EncryptedVirtualPartition.EndSector)
+        {
+            sector -= EncryptedVirtualPartition.StartSector;
+            sector += HiddenVolumeStartSector;
+        }
+        else
+            decrypt = false;
+    }
+
+    result = ReadSectors(destSegment, destOffset, drive, sector, sectorCount);
+    if (result != BiosResult.Success || !decrypt)
+        return result;
+
+    if (BootCryptoInfo.hiddenVolume)
+    {
+        sector -= HiddenVolumeStartSector;
+        sector += PimValueOrHiddenVolumeStartUnitNo;
+    }
+
+    if (drive == EncryptedVirtualPartition.Drive)
+    {
+        while (sectorCount-- > 0)
+        {
+            if (BootCryptoInfo.hiddenVolume || (sector >= EncryptedVirtualPartition.StartSector && sector <= EncryptedVirtualPartition.EndSector))
+            {
+                AcquireSectorBuffer();
+                CopyMemory(destSegment, destOffset, SectorBuffer.ptr, TC_LB_SIZE);
+                DecryptDataUnits(SectorBuffer.ptr, &sector, 1, BootCryptoInfo);
+                CopyMemory(SectorBuffer.ptr, destSegment, destOffset, TC_LB_SIZE);
+                ReleaseSectorBuffer();
+            }
+            ++sector;
+            destOffset += TC_LB_SIZE;
+        }
+    }
+    return result;
+}
+
+BiosResult WriteEncryptedSectors(ushort sourceSegment, ushort sourceOffset, ubyte drive, ulong sector, ushort sectorCount)
+{
+    BiosResult result = BiosResult.Success;
+    AcquireSectorBuffer();
+    ulong dataUnitNo = sector;
+    ulong writeOffset = 0;
+
+    if (BootCryptoInfo.hiddenVolume)
+    {
+        if (ReadWritePartiallyCoversEncryptedArea(sector, sectorCount))
+            return BiosResult.InvalidFunction;
+        writeOffset = HiddenVolumeStartSector;
+        writeOffset -= EncryptedVirtualPartition.StartSector;
+        dataUnitNo -= EncryptedVirtualPartition.StartSector;
+        dataUnitNo += PimValueOrHiddenVolumeStartUnitNo;
+    }
+
+    while (sectorCount-- > 0)
+    {
+        CopyMemory(sourceSegment, sourceOffset, SectorBuffer.ptr, TC_LB_SIZE);
+        if (drive == EncryptedVirtualPartition.Drive && sector >= EncryptedVirtualPartition.StartSector && sector <= EncryptedVirtualPartition.EndSector)
+        {
+            EncryptDataUnits(SectorBuffer.ptr, &dataUnitNo, 1, BootCryptoInfo);
+        }
+        result = ReadWriteSectors(true, SectorBuffer.ptr, drive, sector + writeOffset, 1, true);
+        if (BiosResult.Timeout == result)
+        {
+            if (BiosResult.Success == ReadWriteSectors(false, TC_BOOT_LOADER_BUFFER_SEGMENT, 0, drive, sector + writeOffset, 8, false))
+            {
+                CopyMemory(SectorBuffer.ptr, TC_BOOT_LOADER_BUFFER_SEGMENT,0, TC_LB_SIZE);
+                result = ReadWriteSectors(true, TC_BOOT_LOADER_BUFFER_SEGMENT, 0, drive, sector + writeOffset, 8, true);
+            }
+        }
+        if (result != BiosResult.Success)
+        {
+            ulong tmp = sector + writeOffset;
+            PrintDiskError(result, true, drive, &tmp);
+            break;
+        }
+        ++sector;
+        ++dataUnitNo;
+        sourceOffset += TC_LB_SIZE;
+    }
+    ReleaseSectorBuffer();
+    return result;
+}
+
+static bool ReadWritePartiallyCoversEncryptedArea(const ulong sector, ushort sectorCount)
+{
+    ulong readWriteEnd = sector + --sectorCount;
+    return ((sector < EncryptedVirtualPartition.StartSector && readWriteEnd >= EncryptedVirtualPartition.StartSector) ||
+            (sector >= EncryptedVirtualPartition.StartSector && readWriteEnd > EncryptedVirtualPartition.EndSector));
+}

--- a/VeraCryptD/src/Boot/Windows/BootMemory.d
+++ b/VeraCryptD/src/Boot/Windows/BootMemory.d
@@ -1,0 +1,70 @@
+module Boot.Windows.BootMemory;
+
+import Boot.Windows.BootDefs;
+import Boot.Windows.Bios;
+import Boot.Windows.BootDebug;
+
+#pragma pack(push,1)
+struct BiosMemoryMapEntry
+{
+    ulong BaseAddress;
+    ulong Length;
+    uint Type;
+}
+#pragma pack(pop)
+
+static uint MemoryMapContValue;
+
+static bool GetMemoryMapEntry(ref BiosMemoryMapEntry entry)
+{
+    enum uint function = 0x0000E820;
+    enum uint magic = 0x534D4150;
+    enum uint bufferSize = BiosMemoryMapEntry.sizeof;
+    bool carry = false;
+    uint resultMagic;
+    uint resultSize;
+    asm {
+        push es;
+        lea di, function;
+        mov eax, [di];
+        lea di, MemoryMapContValue;
+        mov ebx, [di];
+        lea di, bufferSize;
+        mov ecx, [di];
+        lea di, magic;
+        mov edx, [di];
+        lea di, MemoryMapContValue;
+        mov edi, [di];
+        push TC_BOOT_LOADER_ALT_SEGMENT;
+        pop es;
+        mov di, 0;
+        int 0x15;
+        jnc no_carry;
+        mov carry, 1;
+    no_carry:
+        lea di, resultMagic;
+        mov [di], eax;
+        lea di, MemoryMapContValue;
+        mov [di], ebx;
+        lea di, resultSize;
+        mov [di], ecx;
+        pop es;
+    }
+    CopyMemory(TC_BOOT_LOADER_ALT_SEGMENT, 0, &entry, BiosMemoryMapEntry.sizeof);
+    if (carry)
+        MemoryMapContValue = 0;
+    return resultMagic == magic && resultSize == bufferSize;
+}
+
+bool GetFirstBiosMemoryMapEntry(ref BiosMemoryMapEntry entry)
+{
+    MemoryMapContValue = 0;
+    return GetMemoryMapEntry(entry);
+}
+
+bool GetNextBiosMemoryMapEntry(ref BiosMemoryMapEntry entry)
+{
+    if (MemoryMapContValue == 0)
+        return false;
+    return GetMemoryMapEntry(entry);
+}


### PR DESCRIPTION
## Summary
- translate several boot-related C++ headers and sources to D
- provide implementations for BIOS debug helpers

## Testing
- `make -C VeraCrypt/src` *(fails: Package 'libpcsclite', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863135bf5308327808fe18447046251